### PR TITLE
Split BsdfSampleType enum to distinguish reflection and transmission

### DIFF
--- a/scene/src/material/bsdf.rs
+++ b/scene/src/material/bsdf.rs
@@ -74,11 +74,6 @@ impl BsdfSample {
 
     /// 非Specularのサンプリングかどうか。
     pub fn is_non_specular(&self) -> bool {
-        matches!(
-            self.sample_type,
-            BsdfSampleType::Diffuse
-                | BsdfSampleType::GlossyReflection
-                | BsdfSampleType::GlossyTransmission
-        )
+        !self.is_specular()
     }
 }

--- a/scene/src/material/bsdf.rs
+++ b/scene/src/material/bsdf.rs
@@ -16,10 +16,14 @@ use math::ShadingNormalTangent;
 pub enum BsdfSampleType {
     /// 拡散反射（例：Lambert BSDF）
     Diffuse,
-    /// 完全鏡面反射・透過（例：デルタ関数BSDF）
-    Specular,
+    /// 完全鏡面反射（例：デルタ関数BSDF）
+    SpecularReflection,
+    /// 完全鏡面透過（例：デルタ関数BSDF）
+    SpecularTransmission,
     /// 光沢反射（例：マイクロファセットBSDF）
-    Glossy,
+    GlossyReflection,
+    /// 光沢透過（例：マイクロファセットBSDF）
+    GlossyTransmission,
 }
 
 /// 散乱モードを表す列挙型。
@@ -62,11 +66,19 @@ impl BsdfSample {
 
     /// Specularのサンプリングかどうか。
     pub fn is_specular(&self) -> bool {
-        self.sample_type == BsdfSampleType::Specular
+        matches!(
+            self.sample_type,
+            BsdfSampleType::SpecularReflection | BsdfSampleType::SpecularTransmission
+        )
     }
 
     /// 非Specularのサンプリングかどうか。
     pub fn is_non_specular(&self) -> bool {
-        self.sample_type == BsdfSampleType::Diffuse || self.sample_type == BsdfSampleType::Glossy
+        matches!(
+            self.sample_type,
+            BsdfSampleType::Diffuse
+                | BsdfSampleType::GlossyReflection
+                | BsdfSampleType::GlossyTransmission
+        )
     }
 }

--- a/scene/src/material/bsdf/conductor.rs
+++ b/scene/src/material/bsdf/conductor.rs
@@ -286,7 +286,12 @@ impl ConductorBsdf {
         // BSDF値: F / |cos(theta_i)|
         let f = fresnel / wi_cos_n.abs();
 
-        Some(BsdfSample::new(f, wi, 1.0, BsdfSampleType::Specular))
+        Some(BsdfSample::new(
+            f,
+            wi,
+            1.0,
+            BsdfSampleType::SpecularReflection,
+        ))
     }
 
     /// マイクロファセットサンプリング（Torrance-Sparrow model）。
@@ -310,7 +315,12 @@ impl ConductorBsdf {
         let f = self.evaluate_torrance_sparrow(wo, &wi, &wm);
         let pdf = self.pdf_microfacet(wo, &wi);
 
-        Some(BsdfSample::new(f, wi, pdf, BsdfSampleType::Glossy))
+        Some(BsdfSample::new(
+            f,
+            wi,
+            pdf,
+            BsdfSampleType::GlossyReflection,
+        ))
     }
 
     /// Torrance-Sparrow BRDF を評価する。

--- a/scene/src/material/bsdf/dielectric.rs
+++ b/scene/src/material/bsdf/dielectric.rs
@@ -311,7 +311,7 @@ impl DielectricBsdf {
             SampledSpectrum::constant(f_value),
             wi,
             pdf,
-            BsdfSampleType::Glossy,
+            BsdfSampleType::GlossyReflection,
         ))
     }
 
@@ -350,7 +350,7 @@ impl DielectricBsdf {
             SampledSpectrum::constant(ft),
             wi,
             pdf,
-            BsdfSampleType::Glossy,
+            BsdfSampleType::GlossyTransmission,
         ))
     }
 
@@ -377,7 +377,7 @@ impl DielectricBsdf {
             SampledSpectrum::constant(f_value),
             wi,
             pdf,
-            BsdfSampleType::Glossy,
+            BsdfSampleType::GlossyTransmission,
         ))
     }
 
@@ -449,7 +449,7 @@ impl DielectricBsdf {
                     f,
                     wi,
                     pr / (pr + pt),
-                    BsdfSampleType::Specular,
+                    BsdfSampleType::SpecularReflection,
                 ))
             } else {
                 // Thin surface: 透過方向は入射方向の反対（wi = -wo）
@@ -465,7 +465,7 @@ impl DielectricBsdf {
                     f,
                     wi,
                     pt / (pr + pt),
-                    BsdfSampleType::Specular,
+                    BsdfSampleType::SpecularTransmission,
                 ))
             }
         } else {
@@ -484,7 +484,7 @@ impl DielectricBsdf {
                     f,
                     wi,
                     pr / (pr + pt),
-                    BsdfSampleType::Specular,
+                    BsdfSampleType::SpecularReflection,
                 ))
             } else {
                 // 通常の誘電体: Snellの法則による屈折
@@ -499,7 +499,7 @@ impl DielectricBsdf {
                         f,
                         wt,
                         pt / (pr + pt),
-                        BsdfSampleType::Specular,
+                        BsdfSampleType::SpecularTransmission,
                     ))
                 } else {
                     None

--- a/scene/src/material/bsdf/generalized_schlick.rs
+++ b/scene/src/material/bsdf/generalized_schlick.rs
@@ -258,7 +258,12 @@ impl GeneralizedSchlickBsdf {
                 // BSDF値: F / |cos(theta_i)|
                 let f = fresnel / wi_cos_n.abs();
 
-                Some(BsdfSample::new(f, wi, 1.0, BsdfSampleType::Specular))
+                Some(BsdfSample::new(
+                    f,
+                    wi,
+                    1.0,
+                    BsdfSampleType::SpecularReflection,
+                ))
             }
             ScatterMode::RT => {
                 // 反射と透過
@@ -281,7 +286,7 @@ impl GeneralizedSchlickBsdf {
                         f,
                         wi,
                         pr / (pr + pt),
-                        BsdfSampleType::Specular,
+                        BsdfSampleType::SpecularReflection,
                     ))
                 } else if self.thin_surface {
                     // Thin surface: 反対方向への透過
@@ -298,7 +303,7 @@ impl GeneralizedSchlickBsdf {
                         f,
                         wi,
                         pt / (pr + pt),
-                        BsdfSampleType::Specular,
+                        BsdfSampleType::SpecularTransmission,
                     ))
                 } else {
                     // 通常の誘電体：Snellの法則による屈折
@@ -325,7 +330,7 @@ impl GeneralizedSchlickBsdf {
                             f,
                             wt,
                             pt / (pr + pt),
-                            BsdfSampleType::Specular,
+                            BsdfSampleType::SpecularTransmission,
                         ))
                     } else {
                         None
@@ -410,7 +415,12 @@ impl GeneralizedSchlickBsdf {
 
         let f_value = fresnel * d * g / (4.0 * cos_theta_i * cos_theta_o);
 
-        Some(BsdfSample::new(f_value, wi, pdf, BsdfSampleType::Glossy))
+        Some(BsdfSample::new(
+            f_value,
+            wi,
+            pdf,
+            BsdfSampleType::GlossyReflection,
+        ))
     }
 
     /// マイクロファセット透過サンプリング。
@@ -436,7 +446,12 @@ impl GeneralizedSchlickBsdf {
             // BTDF値
             let f_value = transmission / wi_cos_n.abs();
 
-            Some(BsdfSample::new(f_value, wi, pdf, BsdfSampleType::Glossy))
+            Some(BsdfSample::new(
+                f_value,
+                wi,
+                pdf,
+                BsdfSampleType::GlossyTransmission,
+            ))
         } else {
             // 通常の誘電体：Snellの法則による屈折
             let eta_val = self.eta.value(0);
@@ -471,7 +486,12 @@ impl GeneralizedSchlickBsdf {
             let ft = transmission * d * g * wi.dot(wm).abs() * wo.dot(wm).abs()
                 / (denom * cos_theta_i * cos_theta_o * eta * eta);
 
-            Some(BsdfSample::new(ft, wi, pdf, BsdfSampleType::Glossy))
+            Some(BsdfSample::new(
+                ft,
+                wi,
+                pdf,
+                BsdfSampleType::GlossyTransmission,
+            ))
         }
     }
 

--- a/scene/src/samples.rs
+++ b/scene/src/samples.rs
@@ -85,12 +85,20 @@ impl MaterialSample {
 
     /// Specularのサンプリングかどうか。
     pub fn is_specular(&self) -> bool {
-        self.sample_type == BsdfSampleType::Specular
+        matches!(
+            self.sample_type,
+            BsdfSampleType::SpecularReflection | BsdfSampleType::SpecularTransmission
+        )
     }
 
     /// 非Specularのサンプリングかどうか。
     pub fn is_non_specular(&self) -> bool {
-        self.sample_type == BsdfSampleType::Diffuse || self.sample_type == BsdfSampleType::Glossy
+        matches!(
+            self.sample_type,
+            BsdfSampleType::Diffuse
+                | BsdfSampleType::GlossyReflection
+                | BsdfSampleType::GlossyTransmission
+        )
     }
 
     /// サンプリングが成功したかどうか。


### PR DESCRIPTION
### **User description**
## Summary
• `BsdfSampleType::Specular` を `SpecularReflection` と `SpecularTransmission` に分割
• `BsdfSampleType::Glossy` を `GlossyReflection` と `GlossyTransmission` に分割
• 全てのBSDF実装における新しいサンプルタイプの適切な使用を更新
• 導体材質では反射のみ、誘電体・プラスチック材質では反射と透過の物理的特性に基づく正確な分類を実装
• Lambert材質は引き続き `Diffuse` タイプを使用
• `is_specular()` と `is_non_specular()` メソッドを新しい列挙値に対応するよう更新
• ガラス系材質（Scene 8, 9）および薄膜材質を含む回帰テストが全て合格
• PT/NEE/MISレンダリング戦略の整合性テストが全て合格し、理論的に等価な結果を維持


___

### **PR Type**
Enhancement


___

### **Description**
- BsdfSampleType列挙型を反射と透過に分割

- 全BSDF実装で新しいサンプルタイプを適用

- is_specular/is_non_specularメソッドを更新

- 物理的に正確な反射・透過分類を実装


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bsdf.rs</strong><dd><code>BsdfSampleType列挙型の反射・透過分割</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/bsdf.rs

<li><code>BsdfSampleType</code>列挙型を<code>Specular</code>から<code>SpecularReflection</code>/<code>SpecularTransmission</code>に分割<br> <li> <code>Glossy</code>を<code>GlossyReflection</code>/<code>GlossyTransmission</code>に分割<br> <li> <code>is_specular()</code>と<code>is_non_specular()</code>メソッドを新しい列挙値に対応


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/13/files#diff-f19a6fcd448d8e208ce0f3728e31dbd7d84b1a4bf57aa4d05ee736ec712e3ddb">+17/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conductor.rs</strong><dd><code>導体BSDFの新しいサンプルタイプ適用</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/bsdf/conductor.rs

<li>完全鏡面反射サンプリングで<code>SpecularReflection</code>を使用<br> <li> マイクロファセットサンプリングで<code>GlossyReflection</code>を使用


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/13/files#diff-b81d47969ee2661064983d12ad6e99d3d7d0ead739ed1c6335666b833dc7fef9">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dielectric.rs</strong><dd><code>誘電体BSDFの反射・透過分類更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/bsdf/dielectric.rs

<li>反射サンプリングで<code>GlossyReflection</code>/<code>SpecularReflection</code>を使用<br> <li> 透過サンプリングで<code>GlossyTransmission</code>/<code>SpecularTransmission</code>を使用<br> <li> 薄膜表面とバルク誘電体の両方に対応


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/13/files#diff-d11a26899df152d394f78efa9e1df017e3dac7eef04017c15ff39860c6d60289">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generalized_schlick.rs</strong><dd><code>Schlick BSDFの新しいサンプルタイプ適用</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/bsdf/generalized_schlick.rs

<li>完全鏡面反射で<code>SpecularReflection</code>を使用<br> <li> 完全鏡面透過で<code>SpecularTransmission</code>を使用<br> <li> マイクロファセット反射・透過で<code>GlossyReflection</code>/<code>GlossyTransmission</code>を使用


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/13/files#diff-b4ae0e679228cd4f6f7dbe3b236309d42ab72f62d3ea6ad5966c3cce6dde7815">+27/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>samples.rs</strong><dd><code>MaterialSampleのspecular判定メソッド更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/samples.rs

<li><code>MaterialSample</code>の<code>is_specular()</code>メソッドを新しい列挙値に対応<br> <li> <code>is_non_specular()</code>メソッドを新しい列挙値に対応


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/13/files#diff-1bbd42a1c68ca0fcc4977881211e33723da18335e4298b7624845738a96a03eb">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>