### PR TITLE
Fix MaterialEvaluationResult pdf field comments

### DIFF
--- a/scene/src/material/impls/glass_material.rs
+++ b/scene/src/material/impls/glass_material.rs
@@ -183,7 +183,7 @@ impl BsdfSurfaceMaterial for GlassMaterial {
 
         MaterialEvaluationResult {
             f,
-            pdf: 1.0, // 単一BSDFなので選択確率は1.0
+            pdf: 1.0,
             normal: normal_map,
         }
     }

--- a/scene/src/material/impls/lambert_material.rs
+++ b/scene/src/material/impls/lambert_material.rs
@@ -139,7 +139,7 @@ impl BsdfSurfaceMaterial for LambertMaterial {
 
         MaterialEvaluationResult {
             f,
-            pdf: 1.0, // 単一BSDFなので選択確率は1.0
+            pdf: 1.0,
             normal: normal_map,
         }
     }

--- a/scene/src/material/impls/metal_material.rs
+++ b/scene/src/material/impls/metal_material.rs
@@ -223,7 +223,7 @@ impl BsdfSurfaceMaterial for MetalMaterial {
 
         MaterialEvaluationResult {
             f,
-            pdf: 1.0, // 単一BSDFなので選択確率は1.0
+            pdf: 1.0,
             normal: normal_map,
         }
     }

--- a/scene/src/material/impls/plastic_material.rs
+++ b/scene/src/material/impls/plastic_material.rs
@@ -225,7 +225,7 @@ impl BsdfSurfaceMaterial for PlasticMaterial {
 
         MaterialEvaluationResult {
             f,
-            pdf: 1.0, // 単一BSDFなので選択確率は1.0
+            pdf: 1.0,
             normal: normal_map,
         }
     }

--- a/scene/src/material/impls/simple_pbr_material.rs
+++ b/scene/src/material/impls/simple_pbr_material.rs
@@ -203,7 +203,7 @@ impl BsdfSurfaceMaterial for SimplePbrMaterial {
 
         MaterialEvaluationResult {
             f,
-            pdf: 1.0, // evaluateは決定論的なレイヤー評価
+            pdf: 1.0,
             normal: normal_map,
         }
     }
@@ -338,7 +338,7 @@ impl SimplePbrMaterial {
             alpha,
         );
 
-        let fresnel = generalized_schlick.fresnel(&wo_normalmap).average();
+        let fresnel = generalized_schlick.fresnel(wo_normalmap).average();
 
         if uc < fresnel {
             // Specular反射をサンプリング

--- a/scene/src/samples.rs
+++ b/scene/src/samples.rs
@@ -13,7 +13,7 @@ use crate::material::Material;
 pub struct MaterialEvaluationResult {
     /// BSDF値
     pub f: SampledSpectrum,
-    /// レイヤー選択PDF（レイヤーマテリアルでの確率的BSDF選択用）
+    /// 確率的評価を行うBSDFの評価確率密度関数値
     pub pdf: f32,
     /// 選択されたレイヤーの法線マップ（シェーディング接空間）
     pub normal: Normal<VertexNormalTangent>,


### PR DESCRIPTION
### **User description**
## Summary
• `MaterialEvaluationResult` 構造体の `pdf` フィールドのコメントを正しい意味に修正（「レイヤー選択PDF」から「確率的評価を行うBSDFの評価確率密度関数値」に変更）
• すべてのマテリアル実装ファイルで `MaterialEvaluationResult` 使用時の不正確な `pdf` フィールドコメントを削除
• `pdf` フィールドは確率的にしか評価できないBSDF以外では常に1.0になるべき値であり、レイヤーマテリアル選択用ではない
• 削除したコメント：「単一BSDFなので選択確率は1.0」「evaluateは決定論的なレイヤー評価」


___

### **PR Type**
Documentation


___

### **Description**
- `MaterialEvaluationResult`構造体の`pdf`フィールドコメントを修正

- 全マテリアル実装から不正確な`pdf`フィールドコメントを削除

- BSDFの確率密度関数値の正しい意味に統一

- 一箇所でメソッド呼び出しの不要な参照を修正


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>samples.rs</strong><dd><code>構造体フィールドコメントの修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/samples.rs

<br><li><code>MaterialEvaluationResult</code>の<code>pdf</code>フィールドコメントを「レイヤー選択PDF」から「確率的評価を行うBSDFの評価確率密度関数値」に修正


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/16/files#diff-1bbd42a1c68ca0fcc4977881211e33723da18335e4298b7624845738a96a03eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>glass_material.rs</strong><dd><code>不正確なpdfコメントの削除</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/impls/glass_material.rs

<li><code>MaterialEvaluationResult</code>作成時の<code>pdf</code>フィールドから「単一BSDFなので選択確率は1.0」コメントを削除


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/16/files#diff-c0e687f96a0c2eabc7b230c84222d2ed878b2e11d5fd8ff15e2f4b748f11b04c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lambert_material.rs</strong><dd><code>不正確なpdfコメントの削除</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/impls/lambert_material.rs

<li><code>MaterialEvaluationResult</code>作成時の<code>pdf</code>フィールドから「単一BSDFなので選択確率は1.0」コメントを削除


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/16/files#diff-79822cdcc93b5e339e89a1391e7bb5da856f762a4d88f7476d4da4efa91dc2e8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>metal_material.rs</strong><dd><code>不正確なpdfコメントの削除</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/impls/metal_material.rs

<li><code>MaterialEvaluationResult</code>作成時の<code>pdf</code>フィールドから「単一BSDFなので選択確率は1.0」コメントを削除


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/16/files#diff-cd5987f7f14b036ea9319559d154073fbde161c43822324a490b65357e73535f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plastic_material.rs</strong><dd><code>不正確なpdfコメントの削除</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/impls/plastic_material.rs

<li><code>MaterialEvaluationResult</code>作成時の<code>pdf</code>フィールドから「単一BSDFなので選択確率は1.0」コメントを削除


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/16/files#diff-41e736c91f2652243fb3173653aa685669d39b1e36a67e59831956710112120d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>simple_pbr_material.rs</strong><dd><code>コメント削除とメソッド呼び出し修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/impls/simple_pbr_material.rs

<li><code>MaterialEvaluationResult</code>作成時の<code>pdf</code>フィールドから「evaluateは決定論的なレイヤー評価」コメントを削除<br> <li> <code>fresnel</code>メソッド呼び出しで不要な参照演算子を削除


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/16/files#diff-1672cb3e985ab8aaa6afcb6eaa976eaa2b060ac5871b69c8a251292ef883c3bb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>