### PR TITLE
Remove unnecessary secondary wavelength termination for BSDF reflections

### DIFF
--- a/scene/src/material/bsdf/dielectric.rs
+++ b/scene/src/material/bsdf/dielectric.rs
@@ -249,9 +249,8 @@ impl DielectricBsdf {
         } else {
             SampledSpectrum::one() / self.eta.clone() // 誘電体(n) → 空気(1.0): eta = 1/n
         };
-        let eta_scalar = eta_spectrum.value(0); // 屈折計算用
+        let eta_scalar = eta_spectrum.value(0);
 
-        // フレネル反射率を計算
         let wo_dot_wm = wo.dot(wm);
         let fresnel = fresnel_dielectric(wo_dot_wm.abs(), &eta_spectrum);
         let pr = fresnel.average();
@@ -438,9 +437,8 @@ impl DielectricBsdf {
         } else {
             SampledSpectrum::one() / self.eta.clone() // 誘電体(n) → 空気(1.0): eta = 1/n
         };
-        let etap_scalar = eta_spectrum.value(0); // 屈折計算用
+        let etap_scalar = eta_spectrum.value(0);
 
-        // フレネル反射率を計算
         let fresnel = fresnel_dielectric(wo_cos_n.abs(), &eta_spectrum);
 
         if self.thin_surface {
@@ -573,7 +571,7 @@ impl DielectricBsdf {
         } else {
             SampledSpectrum::one() / self.eta.clone() // 誘電体(n) → 空気(1.0): eta = 1/n
         };
-        let eta_scalar = eta_spectrum.value(0); // 屈折計算用
+        let eta_scalar = eta_spectrum.value(0);
 
         // Generalized half vectorを計算
         let wm = match self.compute_generalized_half_vector(wo, wi, eta_scalar) {
@@ -581,7 +579,6 @@ impl DielectricBsdf {
             None => return SampledSpectrum::zero(),
         };
 
-        // フレネル反射率を計算
         let fresnel = fresnel_dielectric(wo.dot(wm).abs(), &eta_spectrum);
 
         // 反射か透過かを判定
@@ -620,7 +617,7 @@ impl DielectricBsdf {
         } else {
             SampledSpectrum::one() / self.eta.clone() // 誘電体(n) → 空気(1.0): eta = 1/n
         };
-        let eta_scalar = eta_spectrum.value(0); // 屈折計算用
+        let eta_scalar = eta_spectrum.value(0);
 
         // Generalized half vectorを計算
         let wm = match self.compute_generalized_half_vector(wo, wi, eta_scalar) {
@@ -628,7 +625,6 @@ impl DielectricBsdf {
             None => return 0.0,
         };
 
-        // フレネル反射率を計算
         let fresnel = fresnel_dielectric(wo.dot(wm).abs(), &eta_spectrum);
         let pr = fresnel.average();
         let pt = 1.0 - pr;

--- a/scene/src/material/bsdf/generalized_schlick.rs
+++ b/scene/src/material/bsdf/generalized_schlick.rs
@@ -597,7 +597,6 @@ impl GeneralizedSchlickBsdf {
                 return SampledSpectrum::zero();
             }
 
-            // フレネル透過率を計算
             let fresnel = self.generalized_schlick_fresnel(wo.z().abs());
             let transmission = SampledSpectrum::one() - fresnel;
 
@@ -612,7 +611,7 @@ impl GeneralizedSchlickBsdf {
             } else {
                 SampledSpectrum::one() / self.eta.clone() // 誘電体(n) → 空気(1.0): eta = 1/n
             };
-            let eta_scalar = eta_spectrum.value(0); // 屈折計算用
+            let eta_scalar = eta_spectrum.value(0);
 
             // Generalized half vectorを計算
             let wm = match self.compute_generalized_half_vector(wo, wi, eta_scalar) {
@@ -620,7 +619,6 @@ impl GeneralizedSchlickBsdf {
                 None => return SampledSpectrum::zero(),
             };
 
-            // フレネル透過率を計算
             let fresnel_dielectric_spectrum = fresnel_dielectric(wo.dot(wm).abs(), &eta_spectrum);
             let transmission = SampledSpectrum::one() - fresnel_dielectric_spectrum;
 
@@ -631,8 +629,6 @@ impl GeneralizedSchlickBsdf {
 
             let numerator = d * transmission * g * wi.dot(wm).abs() * wo.dot(wm).abs();
             let denominator = denom * abs_cos_theta(wi) * abs_cos_theta(wo);
-
-            
 
             numerator / denominator / (eta_scalar * eta_scalar)
         }
@@ -716,7 +712,6 @@ impl GeneralizedSchlickBsdf {
                     // 反射PDF
                     let pdf_refl = self.pdf_reflection(wo, wi);
 
-                    // フレネル反射率で重み付け
                     let eta_spectrum = if self.entering {
                         self.eta.clone()
                     } else {
@@ -731,7 +726,6 @@ impl GeneralizedSchlickBsdf {
                     // 透過PDF
                     let pdf_trans = self.pdf_transmission(wo, wi);
 
-                    // フレネル透過率で重み付け
                     let eta_spectrum = if self.entering {
                         self.eta.clone()
                     } else {

--- a/scene/src/material/common.rs
+++ b/scene/src/material/common.rs
@@ -79,24 +79,21 @@ pub fn sample_uniform_disk_polar(u: glam::Vec2) -> glam::Vec2 {
     glam::Vec2::new(r * theta.cos(), r * theta.sin())
 }
 
-/// 誘電体のフレネル反射率を計算する（スペクトル対応）。
+/// 誘電体のフレネル反射率を計算する。
 ///
 /// # Arguments
 /// - `cos_theta_i` - 入射角のコサイン値
-/// - `eta` - 屈折率の比（透過側/入射側、スペクトル依存）
+/// - `eta` - 屈折率の比（透過側/入射側）
 pub fn fresnel_dielectric(cos_theta_i: f32, eta: &SampledSpectrum) -> SampledSpectrum {
     let cos_theta_i = cos_theta_i.clamp(0.0, 1.0);
 
-    // Snellの法則で透過角を計算
     let sin2_theta_i = 1.0 - cos_theta_i * cos_theta_i;
     let sin2_theta_t_spectrum =
         SampledSpectrum::constant(sin2_theta_i) / (eta.clone() * eta.clone());
 
-    // 全反射判定とcos_theta_t計算をSampledSpectrumで処理
     let one = SampledSpectrum::one();
     let cos_theta_t_spectrum = (one - sin2_theta_t_spectrum).clamp(0.0, 1.0).sqrt();
 
-    // フレネル方程式をSampledSpectrumで計算
     let cos_theta_i_spectrum = SampledSpectrum::constant(cos_theta_i);
 
     let r_parl = (eta.clone() * cos_theta_i_spectrum.clone() - cos_theta_t_spectrum.clone())

--- a/scene/src/material/impls/simple_pbr_material.rs
+++ b/scene/src/material/impls/simple_pbr_material.rs
@@ -338,7 +338,7 @@ impl SimplePbrMaterial {
             alpha,
         );
 
-        let fresnel = generalized_schlick.fresnel(&wo_normalmap).average();
+        let fresnel = generalized_schlick.fresnel(wo_normalmap).average();
 
         if uc < fresnel {
             // Specular反射をサンプリング


### PR DESCRIPTION
### **User description**
## Summary
• dielectric.rsとgeneralized_schlick.rsのフレネル反射をSampledSpectrumとして扱うように修正
• 反射時には全波長を処理し、屈折時のみ波長依存屈折率の場合に二次波長を終了するように変更
• conductor.rsの実装を参考にしてスペクトル依存フレネル反射率を適切に計算
• フレネル反射率をf32からSampledSpectrumに変更してより正確なスペクトルレンダリングを実現


___

### **PR Type**
Enhancement


___

### **Description**
- BSDF反射でスペクトル依存フレネル反射率を適切に処理

- 反射時の不要な二次波長終了を削除

- 屈折時のみ波長依存屈折率で二次波長を終了

- フレネル反射率をf32からSampledSpectrumに変更


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dielectric.rs</strong><dd><code>誘電体BSDFでスペクトル依存フレネル反射率を実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/bsdf/dielectric.rs

<li>スペクトル依存フレネル反射率計算メソッド<code>fresnel_dielectric_spectral</code>を追加<br> <li> 反射時の不要な<code>terminate_secondary()</code>呼び出しを削除<br> <li> 屈折時のみ波長依存屈折率で二次波長を終了するよう修正<br> <li> フレネル反射率をf32からSampledSpectrumに変更してスペクトル計算を改善


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/17/files#diff-d11a26899df152d394f78efa9e1df017e3dac7eef04017c15ff39860c6d60289">+84/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generalized_schlick.rs</strong><dd><code>Generalized Schlick BSDFで波長終了処理を最適化</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/bsdf/generalized_schlick.rs

<li>反射時の不要な<code>terminate_secondary()</code>呼び出しを削除<br> <li> 屈折時のみ波長依存屈折率で二次波長を終了するよう修正<br> <li> サンプリングメソッドに<code>wavelengths</code>パラメータを追加


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/17/files#diff-b4ae0e679228cd4f6f7dbe3b236309d42ab72f62d3ea6ad5966c3cce6dde7815">+20/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simple_pbr_material.rs</strong><dd><code>SimplePbrMaterialでフレネル計算の引数を修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scene/src/material/impls/simple_pbr_material.rs

- `fresnel`メソッド呼び出しでの参照渡しを値渡しに修正


</details>


  </td>
  <td><a href="https://github.com/MatchaChoco010/toy-cpu-pathtracing/pull/17/files#diff-1672cb3e985ab8aaa6afcb6eaa976eaa2b060ac5871b69c8a251292ef883c3bb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>