### PR TITLE
ScatterModeにTを追加してGeneralizedSchlickBsdfを拡張

### DIFF
--- a/renderer/src/scene/scene_16.rs
+++ b/renderer/src/scene/scene_16.rs
@@ -1,12 +1,12 @@
 //! シーン16: Cornell box with clearcoat PBR bunny
 
-use color::{tone_map::NoneToneMap, ColorSrgb};
+use color::{ColorSrgb, tone_map::NoneToneMap};
 use math::{Point3, Transform, Vector3};
 use scene::{
     CreatePrimitiveDesc, EmissiveMaterial, FloatParameter, LambertMaterial, NormalParameter,
     SimpleClearcoatPbrMaterial, SpectrumParameter,
 };
-use spectrum::{presets, RgbAlbedoSpectrum};
+use spectrum::{RgbAlbedoSpectrum, presets};
 
 use crate::{camera::Camera, filter::Filter};
 

--- a/scene/src/material/bsdf.rs
+++ b/scene/src/material/bsdf.rs
@@ -33,6 +33,8 @@ pub enum BsdfSampleType {
 pub enum ScatterMode {
     /// 反射のみ
     R,
+    /// 透過のみ
+    T,
     /// 反射と透過
     RT,
 }

--- a/scene/src/material/bsdf/generalized_schlick.rs
+++ b/scene/src/material/bsdf/generalized_schlick.rs
@@ -433,12 +433,7 @@ impl GeneralizedSchlickBsdf {
                 if !self.eta.is_constant() {
                     wavelengths.terminate_secondary();
                 }
-                self.sample_microfacet_transmission(
-                    wo,
-                    &wm,
-                    SampledSpectrum::one() - fresnel,
-                    1.0,
-                )
+                self.sample_microfacet_transmission(wo, &wm, SampledSpectrum::one() - fresnel, 1.0)
             }
             ScatterMode::RT => {
                 // 反射と透過

--- a/scene/src/material/bsdf/generalized_schlick.rs
+++ b/scene/src/material/bsdf/generalized_schlick.rs
@@ -221,6 +221,7 @@ impl GeneralizedSchlickBsdf {
         uv: glam::Vec2,
         uc: f32,
         wavelengths: &mut SampledWavelengths,
+        mode: ScatterMode,
     ) -> Option<BsdfSample> {
         let wo_cos_n = wo.z();
         if wo_cos_n == 0.0 {
@@ -229,10 +230,10 @@ impl GeneralizedSchlickBsdf {
 
         if self.effectively_smooth() {
             // 完全鏡面反射/透過
-            self.sample_specular(wo, uc, wavelengths)
+            self.sample_specular(wo, uc, wavelengths, mode)
         } else {
             // マイクロファセットサンプリング
-            self.sample_microfacet(wo, uv, uc, wavelengths)
+            self.sample_microfacet(wo, uv, uc, wavelengths, mode)
         }
     }
 
@@ -242,13 +243,14 @@ impl GeneralizedSchlickBsdf {
         wo: &Vector3<ShadingNormalTangent>,
         uc: f32,
         wavelengths: &mut SampledWavelengths,
+        mode: ScatterMode,
     ) -> Option<BsdfSample> {
         let wo_cos_n = wo.z();
 
         // フレネル反射率を計算
         let fresnel = self.generalized_schlick_fresnel(wo_cos_n.abs());
 
-        match self.scatter_mode {
+        match mode {
             ScatterMode::R => {
                 // 反射のみ
                 let wi = Vector3::new(-wo.x(), -wo.y(), wo.z());
@@ -267,6 +269,64 @@ impl GeneralizedSchlickBsdf {
                     1.0,
                     BsdfSampleType::SpecularReflection,
                 ))
+            }
+            ScatterMode::T => {
+                // 透過のみ
+                let pt = 1.0 - fresnel.average();
+                if pt == 0.0 {
+                    return None;
+                }
+
+                if self.thin_surface {
+                    // Thin surface: 反対方向への透過
+                    let wi = Vector3::new(-wo.x(), -wo.y(), -wo.z());
+                    let wi_cos_n = wi.z();
+
+                    if wi_cos_n == 0.0 {
+                        return None;
+                    }
+
+                    let transmission = SampledSpectrum::one() - fresnel;
+                    let f = transmission / wi_cos_n.abs();
+                    Some(BsdfSample::new(
+                        f,
+                        wi,
+                        1.0,
+                        BsdfSampleType::SpecularTransmission,
+                    ))
+                } else {
+                    // 通常の誘電体：Snellの法則による屈折（波長制限）
+                    if !self.eta.is_constant() {
+                        wavelengths.terminate_secondary();
+                    }
+
+                    let eta_val = self.eta.value(0);
+                    let (eta_i, eta_t) = if self.entering {
+                        (1.0, eta_val)
+                    } else {
+                        (eta_val, 1.0)
+                    };
+                    let eta = eta_t / eta_i;
+                    let n = Vector3::new(0.0, 0.0, 1.0);
+
+                    if let Some(wt) = refract(wo, &n, eta) {
+                        let wt_cos_n = wt.z();
+                        if wt_cos_n == 0.0 {
+                            return None;
+                        }
+
+                        let transmission = SampledSpectrum::one() - fresnel;
+                        let f = transmission / (eta * eta * wt_cos_n.abs());
+                        Some(BsdfSample::new(
+                            f,
+                            wt,
+                            1.0,
+                            BsdfSampleType::SpecularTransmission,
+                        ))
+                    } else {
+                        None
+                    }
+                }
             }
             ScatterMode::RT => {
                 // 反射と透過
@@ -354,6 +414,7 @@ impl GeneralizedSchlickBsdf {
         uv: glam::Vec2,
         uc: f32,
         wavelengths: &mut SampledWavelengths,
+        mode: ScatterMode,
     ) -> Option<BsdfSample> {
         // 可視法線をサンプリング
         let wm = self.sample_visible_normal(wo, uv);
@@ -362,10 +423,22 @@ impl GeneralizedSchlickBsdf {
         let wo_dot_wm = wo.dot(wm);
         let fresnel = self.generalized_schlick_fresnel(wo_dot_wm.abs());
 
-        match self.scatter_mode {
+        match mode {
             ScatterMode::R => {
                 // 反射のみ
                 self.sample_microfacet_reflection(wo, &wm, fresnel, 1.0)
+            }
+            ScatterMode::T => {
+                // 透過のみ
+                if !self.eta.is_constant() {
+                    wavelengths.terminate_secondary();
+                }
+                self.sample_microfacet_transmission(
+                    wo,
+                    &wm,
+                    SampledSpectrum::one() - fresnel,
+                    1.0,
+                )
             }
             ScatterMode::RT => {
                 // 反射と透過
@@ -549,6 +622,13 @@ impl GeneralizedSchlickBsdf {
                 // 反射のみ評価
                 self.evaluate_reflection(wo, wi)
             }
+            ScatterMode::T => {
+                if is_reflection {
+                    return SampledSpectrum::zero();
+                }
+                // 透過のみ評価
+                self.evaluate_transmission(wo, wi)
+            }
             ScatterMode::RT => {
                 if is_reflection {
                     // 反射評価
@@ -706,6 +786,13 @@ impl GeneralizedSchlickBsdf {
                 }
                 // 反射PDFのみ
                 self.pdf_reflection(wo, wi)
+            }
+            ScatterMode::T => {
+                if is_reflection {
+                    return 0.0;
+                }
+                // 透過PDFのみ
+                self.pdf_transmission(wo, wi)
             }
             ScatterMode::RT => {
                 if is_reflection {

--- a/scene/src/material/impls/simple_pbr_clearcoat_material.rs
+++ b/scene/src/material/impls/simple_pbr_clearcoat_material.rs
@@ -8,9 +8,9 @@ use math::{Normal, ShadingNormalTangent, Transform, Vector3, VertexNormalTangent
 use spectrum::{SampledSpectrum, SampledWavelengths};
 
 use crate::{
-    material::bsdf::{GeneralizedSchlickBsdf, NormalizedLambertBsdf, ScatterMode},
     BsdfSurfaceMaterial, FloatParameter, Material, MaterialEvaluationResult, MaterialSample,
     NormalParameter, SpectrumParameter, SurfaceInteraction, SurfaceMaterial,
+    material::bsdf::{GeneralizedSchlickBsdf, NormalizedLambertBsdf, ScatterMode},
 };
 
 /// シンプルなクリアコート付きPBRマテリアル。
@@ -190,7 +190,7 @@ impl BsdfSurfaceMaterial for SimpleClearcoatPbrMaterial {
         if uc < clearcoat_fresnel {
             // clearcoat層をサンプリング
             let uc_adjusted = uc / clearcoat_fresnel;
-            match clearcoat_bsdf.sample(&wo_normalmap, uv, uc_adjusted, lambda) {
+            match clearcoat_bsdf.sample(&wo_normalmap, uv, uc_adjusted, lambda, ScatterMode::R) {
                 Some(bsdf_result) => {
                     let wi_shading = &transform_inv * &bsdf_result.wi;
                     MaterialSample::new(
@@ -612,7 +612,7 @@ impl SimpleClearcoatPbrMaterial {
             alpha,
         );
 
-        match generalized_schlick.sample(wo_normalmap, uv, 0.0, lambda) {
+        match generalized_schlick.sample(wo_normalmap, uv, 0.0, lambda, ScatterMode::R) {
             Some(bsdf_result) => {
                 let wi_shading = transform_inv * &bsdf_result.wi;
                 MaterialSample::new(
@@ -664,7 +664,7 @@ impl SimpleClearcoatPbrMaterial {
         if uc < fresnel {
             // Specular反射をサンプリング
             let uc = uc / fresnel;
-            match generalized_schlick.sample(wo_normalmap, uv, uc, lambda) {
+            match generalized_schlick.sample(wo_normalmap, uv, uc, lambda, ScatterMode::R) {
                 Some(bsdf_result) => {
                     let wi_shading = transform_inv * &bsdf_result.wi;
                     MaterialSample::new(

--- a/scene/src/material/impls/simple_pbr_material.rs
+++ b/scene/src/material/impls/simple_pbr_material.rs
@@ -303,7 +303,7 @@ impl SimplePbrMaterial {
             alpha,
         );
 
-        match generalized_schlick.sample(wo_normalmap, uv, 0.0, lambda) {
+        match generalized_schlick.sample(wo_normalmap, uv, 0.0, lambda, ScatterMode::R) {
             Some(bsdf_result) => {
                 let wi_shading = transform_inv * &bsdf_result.wi;
                 MaterialSample::new(
@@ -355,7 +355,7 @@ impl SimplePbrMaterial {
         if uc < fresnel {
             // Specular反射をサンプリング
             let uc = uc / fresnel;
-            match generalized_schlick.sample(wo_normalmap, uv, uc, lambda) {
+            match generalized_schlick.sample(wo_normalmap, uv, uc, lambda, ScatterMode::R) {
                 Some(bsdf_result) => {
                     let wi_shading = transform_inv * &bsdf_result.wi;
                     MaterialSample::new(


### PR DESCRIPTION
## Summary
• `ScatterMode`列挙型に`T`（透過のみ）を追加し、既存の`R`（反射のみ）と`RT`（反射+透過）に加えて透過のみのサンプリングを可能にした
• `GeneralizedSchlickBsdf::sample()`メソッドに`ScatterMode`パラメータを追加し、指定されたモードに応じて適切な散乱をサンプリングするように実装
• `evaluate()`および`pdf()`メソッドでもScatterModeに応じて透過のみを返すパスを実装
• 完全鏡面反射（smooth surface）とマイクロファセット両方で透過のみモードに対応
• thin surfaceと通常の誘電体の両方で透過のみモードが正しく動作
• すべての既存マテリアル実装（`SimplePbrMaterial`、`SimpleClearcoatPbrMaterial`）で新しいAPIシグネチャに更新
• レンダラー一貫性テストが全て通過し、理論的に等価なレンダリング戦略間で一貫した結果を生成することを確認